### PR TITLE
Expand pediatric database with 65 new medications

### DIFF
--- a/GITHUB_SETUP.md
+++ b/GITHUB_SETUP.md
@@ -90,7 +90,7 @@ tinydose-pwa/
 │   ├── 🖼️ pwa-192x192.png         # App icon (192x192)
 │   ├── 🖼️ pwa-512x512.png         # App icon (512x512)  
 │   ├── 🖼️ apple-touch-icon.png    # iOS home screen icon
-│   ├── 📊 pediatric_drugs.csv     # Complete drug database (444 medications)
+│   ├── 📊 pediatric_drugs.csv     # Complete drug database (509 medications)
 │   └── 📱 manifest.webmanifest    # PWA manifest
 ├── 📁 src/                        # Source code
 │   ├── 📁 components/             # React components

--- a/PWA_FEATURES.md
+++ b/PWA_FEATURES.md
@@ -119,7 +119,7 @@
 - **Total Size**: ~10MB (including all assets)
 - **Initial Load**: ~400KB critical resources
 - **Offline Size**: ~10MB cached data
-- **Drug Records**: 444 medications
+- **Drug Records**: 509 medications
 - **Medical Systems**: 23 specialties covered
 - **Languages**: English (expandable)
 

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ tinydose-pwa/
 - **Windows**: Integrates with Start Menu and taskbar
 
 ### Offline Capabilities
-- **Complete Drug Database**: 444 medications cached locally
+- **Complete Drug Database**: 509 medications cached locally
 - **Full Calculator**: All dosing functions work offline
 - **Settings Persistence**: Favorites and preferences saved
 - **Service Worker**: Automatic updates when online

--- a/REPOSITORY_READY.md
+++ b/REPOSITORY_READY.md
@@ -42,7 +42,7 @@ tinydose-pediatric-calculator/
 │   ├── 📄 main.tsx               # React entry point
 │   ├── 📄 index.css              # Global styles with TailwindCSS
 │   ├── 📂 components/            # React components
-│   │   ├── 🔍 DrugSearch.tsx     # Drug search with all 444 medications
+│   │   ├── 🔍 DrugSearch.tsx     # Drug search with all 509 medications
 │   │   ├── 🧮 DosageCalculator.tsx # Dose calculation engine
 │   │   └── 🎨 SplashScreen.tsx   # PWA splash screen
 │   ├── 📂 lib/                   # Utilities
@@ -68,7 +68,7 @@ The `public/pediatric_drugs.csv` contains the complete database:
 
 ### ✅ Search Functionality Fixed
 - Removed 50-drug limitation from DrugSearch component
-- All 444 medications are now searchable and accessible
+- All 509 medications are now searchable and accessible
 - Advanced filtering by medical system
 - Intelligent search across drug names, indications, and classes
 

--- a/public/pediatric_drugs.csv
+++ b/public/pediatric_drugs.csv
@@ -443,4 +443,68 @@ Vaccinology,MMR,Live attenuated,Measles mumps rubella,0.5 mL SQ at 12-15 mo 4-6 
 Vaccinology,IPV,Inactivated polio,Polio,0.5 mL IM/SQ at 2 4 6-18 mo 4-6 yrs,0.5 mL,Vial,IM/SQ,4 doses,Anaphylaxis,Local fever,Check schedule
 Vaccinology,Hib,Conjugate,Haemophilus influenzae b,0.5 mL IM at 2 4 6 12-15 mo,0.5 mL,Vial,IM,4 doses,Anaphylaxis,Local fever,Same as above
 Vaccinology,DTaP,Toxoid + acellular pertussis,Diphtheria tetanus pertussis,0.5 mL IM at 2 4 6 15-18 mo 4-6 yrs,0.5 mL,Vial,IM,5 doses,Encephalopathy <7 days post-prev,Local fever fussiness,Shake well
-Vaccinology,Japanese encephalitis,Inactivated,JE,0.5 mL IM 2 doses 28 days apart,,,,,,,
+Vaccinology,Japanese encephalitis,Inactivated,JE,0.5 mL IM 2 doses 28 days apart,,,,,,,Infectious_Diseases,Amikacin,Aminoglycoside,Gram-negative sepsis,15-22.5 mg/kg/day IV ÷ q8-24h,1.5 g/day,Vial,IV,q8-24h,Aminoglycoside allergy,Nephrotoxicity ototoxicity,Monitor serum levels
+Infectious_Diseases,Cefoperazone,3rd gen cephalosporin,Intra-abdominal sepsis,100-150 mg/kg/day IV ÷ q8-12h,6 g/day,Vial,IV,q8-12h,Cephalosporin allergy,Hypoprothrombinemia bleeding risk,Monitor coagulation
+Infectious_Diseases,Cefepime,4th gen cephalosporin,Pseudomonas meningitis,50 mg/kg IV q8-12h,2 g/dose,Vial,IV,q8-12h,Cephalosporin allergy,Rash neutropenia,Adjust in renal failure
+Infectious_Diseases,Ceftazidime,3rd gen cephalosporin,Pseudomonas sepsis,30-50 mg/kg IV q8h,2 g/dose,Vial,IV,q8h,Cephalosporin allergy,Rash thrombophlebitis,Monitor renal function
+Infectious_Diseases,Meropenem,Carbapenem,Meningitis sepsis,20-40 mg/kg IV q8h,2 g/dose,Vial,IV,q8h,Carbapenem allergy,Rash seizures,Adjust in renal impairment
+Infectious_Diseases,Imipenem-Cilastatin,Carbapenem,Polymicrobial sepsis,15-25 mg/kg IV q6h,1 g/dose,Vial,IV,q6h,Carbapenem allergy,Seizures GI upset,Use with caution in CNS disease
+Infectious_Diseases,Piperacillin-Tazobactam,Extended-spectrum penicillin,Intra-abdominal infection,240-300 mg/kg/day IV ÷ q6-8h,16 g/day piperacillin,Vial,IV,q6-8h,Penicillin allergy,Rash thrombocytopenia,Monitor renal function
+Infectious_Diseases,Aztreonam,Monobactam,Gram-negative sepsis,30 mg/kg IV q6-8h,2 g/dose,Vial,IV,q6-8h,Aztreonam allergy,Rash GI upset,Cross-allergenicity minimal with penicillins
+Infectious_Diseases,Doxycycline,Tetracycline,Atypical pneumonia,2-4 mg/kg/day PO/IV ÷ daily-BID,200 mg/day,Cap tab IV,PO/IV,daily-BID,Age <8 yrs pregnancy,Photosensitivity tooth discoloration,Give with food water
+Infectious_Diseases,Linezolid,Oxazolidinone,MRSA pneumonia,10 mg/kg IV/PO q8h,600 mg/dose,Tab susp vial,PO/IV,q8h,MAOI use,Thrombocytopenia neuropathy,Monitor CBC weekly
+Neurological,Clonazepam,Benzodiazepine,Absence seizures,0.01-0.03 mg/kg/day PO ÷ BID-TID,0.2 mg/kg/day,Tab liquid,PO,BID-TID,Severe resp insufficiency,Sedation dependence,Taper slowly
+Neurological,Ethosuximide,Succinimide,Absence seizures,20 mg/kg/day PO ÷ BID titrate to 40 mg/kg/day,1.5 g/day,Caps syrup,PO,BID,Hepatic porphyria,Blood dyscrasias rash,Monitor CBC
+Neurological,Zonisamide,Sulfonamide,Partial seizures,2-4 mg/kg/day PO titrate to 8-12 mg/kg/day,400 mg/day,Cap sprinkle,PO,Once daily,Sulfa allergy,Metabolic acidosis kidney stones,Monitor bicarb
+Neurological,Pregabalin,Anticonvulsant adjuvant,Neuropathic pain,2-4 mg/kg/day PO ÷ BID,300 mg/day,Cap liquid,PO,BID,Hypersensitivity,Dizziness weight gain,Adjust renal
+Neurological,Rufinamide,Triazole,Lennox-Gastaut,10 mg/kg/day PO ÷ BID titrate to 45 mg/kg/day,3.2 g/day,Tab susp,PO,BID,Familial short QT,QT shortening CNS depression,Monitor ECG
+Neurological,Perampanel,AMPA antagonist,Partial seizures,2-4 mg PO qHS titrate to 12 mg qHS,12 mg/day,Tab liquid,PO,qHS,Hypersensitivity,Dizziness aggression,Monitor behavior
+Neurological,Lacosamide,Functionalized amino acid,Partial seizures,2-4 mg/kg/day IV/PO ÷ BID titrate to 10 mg/kg/day,400 mg/day,Tab liquid IV,PO/IV,BID,Cardiac conduction issues,Dizziness PR prolongation,Monitor ECG
+Neurological,Felbamate,Dicarbamate,Lennox-Gastaut,15 mg/kg/day PO ÷ TID-QID titrate to 45 mg/kg/day,3.6 g/day,Tab susp,PO,TID-QID,Bone marrow depression,Aplastic anemia hepatic failure,Black-box warnings
+Neurological,Vigabatrin,GABA transaminase inhibitor,Infantile spasms,50 mg/kg/day PO ÷ BID titrate to 150 mg/kg/day,3 g/day,Powder packet,PO,BID,Retinal disease,Permanent vision loss,Regular eye exams
+Neurological,Cannabidiol,Plant-derived,Dravet Lennox-Gastaut,5 mg/kg/day PO ÷ BID titrate to 20 mg/kg/day,20 mg/kg/day,Solution,PO,BID,Hepatic impairment,Somnolence hepatotoxicity,Monitor LFT
+Neurological,Topiramate sprinkle,Anticonvulsant,Migraine prophylaxis,1-3 mg/kg/day PO titrate to 5-9 mg/kg/day,400 mg/day,Caps sprinkle,PO,BID,Metabolic acidosis,Metabolic acidosis kidney stones,Monitor bicarb
+Gastroenterology,Domperidone,Dopamine antagonist,Gastroparesis,0.25-0.5 mg/kg PO q8h,30 mg/day,Tab,PO,TID,QT prolongation,QT prolongation arrhythmia,ECG before use
+Gastroenterology,Domperidone suspension,Dopamine antagonist,Gastroparesis,0.25-0.5 mg/kg PO q8h,30 mg/day,Susp,PO,TID,QT prolongation,QT prolongation arrhythmia,ECG before use
+Gastroenterology,Itopride,Prokinetic,Functional dyspepsia,0.5-1 mg/kg PO TID,150 mg/day,Tab,PO,TID,GIT hemorrhage,Diarrhea dizziness,Monitor cardiac
+Gastroenterology,Cisapride,Serotonin agonist,Gastroparesis,0.2-0.3 mg/kg PO QID,10 mg/dose,Tab susp,PO,QID,QT prolongation,QT prolongation arrhythmia,Black-box withdrawn
+Gastroenterology,Hyoscine butylbromide,Antispasmodic,Colicky pain,0.3-0.6 mg/kg PO q8h,20 mg/dose,Tab,PO,TID,Glaucoma,Anticholinergic effects,Short-term use
+Gastroenterology,Ornidazole,Nitroimidazole,Amoebiasis giardiasis,25 mg/kg/day PO ÷ BID,1.5 g/day,Tab susp,PO,BID,Nitroimidazole allergy,Metallic taste disulfiram,No alcohol 48 h
+Gastroenterology,Tinidazole,Nitroimidazole,Giardiasis amoebiasis,50-75 mg/kg PO single dose,2 g single,Tab,PO,Single,Nitroimidazole allergy,Metallic taste disulfiram,Give with food
+Gastroenterology,Secnidazole,Nitroimidazole,Giardiasis amoebiasis,30 mg/kg PO single dose,2 g single,Granules,PO,Single,Nitroimidazole allergy,GI upset metallic taste,Single-dose cure
+Gastroenterology,Paromomycin,Aminoglycoside,Intestinal amoebiasis,25-35 mg/kg/day PO ÷ TID,3 g/day,Cap,PO,TID,Intestinal obstruction,GI upset ototoxicity,Monitor hearing
+Gastroenterology,Diloxanide furoate,Luminal amebicide,Asymptomatic amoebiasis,20 mg/kg/day PO ÷ TID max 1.5 g/day,1.5 g/day,Tab,PO,TID,Pregnancy,Flatulence nausea,Give after meals
+Gastroenterology,Cholestyramine,Bile acid sequestrant,Cholestasis pruritus,240 mg/kg/day PO ÷ BID-QID,8 g/day,Powder,PO,BID-QID,Biliary obstruction,Constipation malabsorption,Give other drugs 1 h before
+Gastroenterology,Alosetron,5-HT3 antagonist,Severe IBS-D,Not approved <18 yrs,—,Tab,PO,BID,Constipation,Ischemic colitis,Restricted program
+Gastroenterology,Eluxadoline,µ-& κ-opioid agonist IBS-D,Not approved <18 yrs,—,Tab,PO,BID,Pancreatitis biliary disease,Pancreatitis constipation,Adult only
+Gastroenterology,Ramosetron,5-HT3 antagonist,CINV IBS-D,Not approved <18 yrs,—,Tab,PO,Once daily,Constipation,Constipation headache,Adult only
+Gastroenterology,Ondansetron oral soluble film,5-HT3 antagonist,CINV PONV,0.15 mg/kg PO q8h,16 mg,Film,PO,q8h,Hypersensitivity,Headache constipation QT,Monitor ECG
+Endocrine,Cholecalciferol drops,Vitamin D,Rickets prevention,400-1000 IU PO daily,2000 IU/day,Drops,PO,Once daily,Hypercalcemia,Hypercalcemia,Monitor Ca²⁺
+Endocrine,Ergocalciferol,Vitamin D2,Vitamin D deficiency,1000-5000 IU PO daily,50000 IU/week,Caps liquid,PO,Once daily,Hypercalcemia,Hypercalcemia,Monitor Ca²⁺
+Endocrine,Alfacalcidol,1-α-hydroxy-vitamin D,Hypoparathyroidism,0.05-0.1 mcg/kg PO daily,1 mcg/day,Cap drops,PO,Once daily,Hypercalcemia,Hypercalcemia,Monitor Ca²⁺
+Endocrine,Calcium carbonate chew 500 mg,Calcium,Deficiency,500-1000 mg elemental Ca PO daily,2500 mg/day,Tab chew,PO,Once daily,Hypercalcemia,Constipation,With vitamin D
+Endocrine,Zinc sulfate,Trace element,Zinc deficiency,1-2 mg/kg/day PO ÷ daily-BID,40 mg/day,Syrup tab,PO,Once daily,Renal failure,Nausea copper deficiency,Monitor copper
+Endocrine,Copper sulfate,Trace element,Copper deficiency,20 mcg/kg/day PO,3 mg/day,Drops,PO,Once daily,Wilson disease,Nausea hepatotoxicity,Monitor copper
+Endocrine,Selenium,Trace element,Selenium deficiency,1-2 mcg/kg/day PO,60 mcg/day,Drops,PO,Once daily,None,Nausea hair loss,Monitor levels
+Endocrine,Chromium,Trace element,TPN supplementation,0.2-0.3 mcg/kg/day IV,5 mcg/day,Ampule,IV,Once daily,Renal failure,Nausea dermatitis,Monitor levels
+Endocrine,Molybdenum,Trace element,TPN supplementation,0.25-1 mcg/kg/day IV,10 mcg/day,Ampule,IV,Once daily,None,Nausea anemia,Monitor uric acid
+Endocrine,Manganese,Trace element,TPN supplementation,1 mcg/kg/day IV,50 mcg/day,Ampule,IV,Once daily,Biliary disease,Neurotoxicity,Monitor LFT
+Endocrine,Iodine,Trace element,Deficiency,50-90 mcg/day PO,150 mcg/day,Drops tab,PO,Once daily,Hyperthyroidism,Hyperthyroidism,Monitor thyroid
+Endocrine,Phosphorus supplement,Electrolyte,Hypophosphatemia,0.5-1 mmol/kg/day PO ÷ QID,2 mmol/kg/day,Solution tab,PO,QID,Hyperphosphatemia,Diarrhea,Monitor Ca²⁺
+Endocrine,Sodium phosphate,Electrolyte,Hypophosphatemia,0.15-0.3 mmol/kg IV q6-12h,0.5 mmol/kg,Vial,IV,q6-12h,Hyperphosphatemia,Hypocalcemia,Monitor Ca²⁺
+Endocrine,Potassium phosphate,Electrolyte,Hypophosphatemia,0.15-0.3 mmol/kg IV q6-12h,0.5 mmol/kg,Vial,IV,q6-12h,Hyperphosphatemia,Hypocalcemia,Monitor Ca²⁺
+Respiratory,Budesonide respules,ICS,Asthma <5 yrs,0.25-1 mg neb daily-BID,2 mg/day,Ampule,Neb,Once-BID,Hypersensitivity,Thrush dysphonia,Rinse mouth
+Respiratory,Ipratropium+Albuterol neb,Combo,Severe wheeze,1.5-3 mL q20 min x3 then q4-6h,2 mg ipratropium/day,Neb solution,Inh,q4-6h,Soy allergy,Tachycardia dry mouth,Watch technique
+Respiratory,Fluticasone furoate,Nasal steroid,Allergic rhinitis ≥2 yrs,27.5 mcg/nostril daily,110 mcg/day,Nasal spray,Inh,Once daily,Nasal infection,Nosebleed,Rinse nozzle
+Respiratory,Azelastine nasal spray,Antihistamine,Allergic rhinitis ≥5 yrs,1 spray/nostril BID,2 sprays/day,Nasal spray,Inh,BID,None,Somnolence bitter taste,Rinse nozzle
+Respiratory,Cetirizine oral drops,Antihistamine,Urticaria rhinitis,2.5-10 mg daily,10 mg/day,Drops,PO,Once daily,Hypersensitivity,Drowsiness,Less sedation
+Dermatology,Desonide 0.05 %,Mid-potency TCS,Atopic dermatitis face,BID x ≤2 wks,—,Cream oint lotion,Topical,BID,Infection,Skin atrophy,Face ≤2 wks
+Dermatology,Desoximetasone 0.05 %,High-potency TCS,Psoriasis lichen planus,BID x 2 wks,—,Cream oint gel,Topical,BID,Infection,Atrophy telangiectasia,Limit 2 wks
+Dermatology,Clobetasol 0.05 %,Super-high TCS,Lichen sclerosus,BID x 2 wks max,—,Cream oint,Topical,BID,Infection,Skin atrophy,≤2 wks
+Dermatology,Mupirocin 2 %,Topical antibiotic,Impetigo,TID x 5-7 days,—,Oint cream,Topical,TID,Systemic use,Local irritation,Intranasal form available
+Pain_Management_Anesthesia,Dexmedetomidine IV,α2-agonist,Sedation ICU,0.5-1 mcg/kg load then 0.2-0.7 mcg/kg/h,—,Vial,IV,Continuous,Severe bradycardia,Bradycardia hypotension,Monitor ECG
+Pain_Management_Anesthesia,Nitrous oxide 50-70 %,Inhalational,Procedural sedation,50-70 % in O2,—,Cylinder,Inh,PRN,Pneumothorax,Nausea vomiting,Rapid elimination
+Pain_Management_Anesthesia,Chloral hydrate,Sedative,Sedation for imaging,25-75 mg/kg PO/PR,2 g,Supp syrup,PO/PR,Single,Hepatic failure,Respiratory depression,Monitor airway
+Pain_Management_Anesthesia,Ketamine oral,Dissociative,Procedural sedation,3-10 mg/kg PO,10 mg/kg,Solution,PO,Single,Psychosis,Hypertension emergence,Airway ready
+Fluid_Electrolyte,Calcium gluconate 10 %,Electrolyte,Hypocalcemia,100-200 mg/kg IV slow,—,Ampule,IV,q6-8h,Hypercalcemia,Bradycardia,Monitor ECG
+Fluid_Electrolyte,Potassium phosphate,Electrolyte,Hypophosphatemia,0.15-0.3 mmol/kg IV q6-12h,0.5 mmol/kg,Vial,IV,q6-12h,Hyperphosphatemia,Hypocalcemia,Monitor Ca²⁺

--- a/src/components/SplashScreen.tsx
+++ b/src/components/SplashScreen.tsx
@@ -57,7 +57,7 @@ export default function SplashScreen() {
         {/* Medical Badge */}
         <div className="flex items-center justify-center space-x-2 text-sm text-gray-500 dark:text-gray-400">
           <div className="w-2 h-2 bg-green-500 rounded-full animate-pulse"></div>
-          <span className="font-medium">444 medications • 23 specialties • PWA ready</span>
+          <span className="font-medium">509 medications • 23 specialties • PWA ready</span>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Added 65 new pediatric medications expanding database from 444 to 509 drugs total. Includes advanced antibiotics, anticonvulsants, GI medications, trace elements, dermatology treatments, and ICU sedation drugs.

₍ᐢ•(ܫ)•ᐢ₎ Generated by [Scout](https://scout.new) ([view jam](https://scout.new/jam/f32f1454-e412-4463-8efd-cfd6ebe965d7))